### PR TITLE
Added generation of jar with runtime dependencies in Maven

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,29 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>3.1.0</version>
+        <configuration>
+          <shadedArtifactAttached>false</shadedArtifactAttached>
+          <createDependencyReducedPom>false</createDependencyReducedPom>
+          <relocations>
+            <relocation>
+              <pattern>javassist</pattern>
+              <shadedPattern>jbse.javassist</shadedPattern>
+            </relocation>
+          </relocations>
+        </configuration>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
     <pluginManagement>
       <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,7 @@
         <artifactId>maven-shade-plugin</artifactId>
         <version>3.1.0</version>
         <configuration>
+          <finalName>${project.artifactId}-shaded-${project.version}</finalName>
           <shadedArtifactAttached>false</shadedArtifactAttached>
           <createDependencyReducedPom>false</createDependencyReducedPom>
           <relocations>


### PR DESCRIPTION
The uber jar (`jbse-0.8.0-SNAPSHOT.jar`) is placed in `/target` together with the original one (`original-jbse-0.8.0-SNAPSHOT.jar`).
The uber jar renames `javassist` as `jbse.javassist` to avoid potential conflict during analysis.

The jar is built during `package`.