### PR TITLE
refactor: add supertype conversion for narrow and widen conversion

### DIFF
--- a/src/main/java/jbse/val/Conversion.java
+++ b/src/main/java/jbse/val/Conversion.java
@@ -1,0 +1,103 @@
+package jbse.val;
+
+import jbse.common.Type;
+import jbse.val.exc.InvalidOperandException;
+import jbse.val.exc.InvalidTypeException;
+import jbse.val.exc.ValueDoesNotSupportNativeException;
+
+/**
+ * Created by Benjamin DANGLOT
+ * benjamin.danglot@inria.fr
+ * on 02/03/18
+ */
+public abstract class Conversion extends Primitive {
+
+    protected final Primitive arg;
+    protected final String toString;
+    protected final int hashCode;
+
+    protected Conversion(char type, Calculator calc, Primitive arg)
+            throws InvalidOperandException, InvalidTypeException {
+        super(type, calc);
+
+        //checks on parameters
+        if (arg == null) {
+            throw new InvalidOperandException("null operand in "+ this.conversionAsString() + "ing construction");
+        }
+        if (!Type.narrows(type, arg.getType())) {
+            throw new InvalidTypeException("cannot " + this.conversionAsString() + " type " + arg.getType() + " to type " + type);
+        }
+        this.arg = arg;
+
+        //calculates hashCode
+        final int prime = getPrime();
+        int result = 1;
+        result = prime * result + arg.hashCode();
+        result = prime * result + type;
+        this.hashCode = result;
+
+        //calculates toString
+        this.toString = this.conversionAsString().toUpperCase() + "-" + this.getType() + "(" + arg.toString() + ")";
+    }
+
+    protected abstract String conversionAsString();
+
+    protected abstract int getPrime();
+
+    public Primitive getArg() {
+        return this.arg;
+    }
+
+    @Override
+    public boolean surelyTrue() {
+        return false;
+    }
+
+    @Override
+    public boolean surelyFalse() {
+        return false;
+    }
+
+    @Override
+    public boolean isSymbolic() {
+        return true;
+    }
+
+    @Override
+    public Object getValueForNative() throws ValueDoesNotSupportNativeException {
+        throw new ValueDoesNotSupportNativeException();
+    }
+
+    @Override
+    public String toString() {
+        return this.toString;
+    }
+
+    @Override
+    public int hashCode() {
+        return this.hashCode;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        final Conversion other = (Conversion) obj;
+        if (arg == null) {
+            if (other.arg != null) {
+                return false;
+            }
+        } else if (!arg.equals(other.arg)) {
+            return false;
+        }
+        return true;
+    }
+
+}

--- a/src/main/java/jbse/val/NarrowingConversion.java
+++ b/src/main/java/jbse/val/NarrowingConversion.java
@@ -12,99 +12,30 @@ import jbse.val.exc.ValueDoesNotSupportNativeException;
  * @author Pietro Braione
  *
  */
-public final class NarrowingConversion extends Primitive {
-    private final Primitive arg;
-    private final String toString;
-    private final int hashCode;
+public final class NarrowingConversion extends Conversion {
 
-    private NarrowingConversion(char type, Calculator calc, Primitive arg) 
-    throws InvalidOperandException, InvalidTypeException {
-        super(type, calc);
+	private NarrowingConversion(char type, Calculator calc, Primitive arg)
+			throws InvalidOperandException, InvalidTypeException {
+		super(type, calc, arg);
+	}
 
-        //checks on parameters
-        if (arg == null) {
-            throw new InvalidOperandException("null operand in narrowing construction");
-        }
-        if (!Type.narrows(type, arg.getType())) {
-            throw new InvalidTypeException("cannot narrow type " + arg.getType() + " to type " + type);
-        }
-        this.arg = arg;
+	@Override
+	protected String conversionAsString() {
+		return "narrow";
+	}
 
-        //calculates hashCode
-        final int prime = 311;
-        int result = 1;
-        result = prime * result + arg.hashCode();
-        result = prime * result + type;
-        this.hashCode = result;
+	@Override
+	protected int getPrime() {
+		return 311;
+	}
 
-        //calculates toString
-        this.toString = "NARROW-"+ this.getType() + "(" + arg.toString() + ")";
-    }
+	public static NarrowingConversion make(char type, Calculator calc, Primitive arg) 
+	throws InvalidOperandException, InvalidTypeException {
+		return new NarrowingConversion(type, calc, arg);
+	}
 
-    public static NarrowingConversion make(char type, Calculator calc, Primitive arg) 
-    throws InvalidOperandException, InvalidTypeException {
-        return new NarrowingConversion(type, calc, arg);
-    }
-
-    public Primitive getArg() {
-        return this.arg;
-    }
-
-    @Override
-    public void accept(PrimitiveVisitor v) throws Exception {
-        v.visitNarrowingConversion(this);
-    }
-
-    @Override
-    public boolean surelyTrue() {
-        return false;
-    }
-
-    @Override
-    public boolean surelyFalse() {
-        return false;
-    }
-
-    @Override
-    public boolean isSymbolic() {
-        return true;
-    }
-
-    @Override
-    public Object getValueForNative() throws ValueDoesNotSupportNativeException {
-        throw new ValueDoesNotSupportNativeException();
-    }
-
-    @Override
-    public String toString() {
-        return this.toString;
-    }
-
-    @Override
-    public int hashCode() {
-        return this.hashCode;
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        if (this == obj) {
-            return true;
-        }
-        if (obj == null) {
-            return false;
-        }
-        if (getClass() != obj.getClass()) {
-            return false;
-        }
-        final NarrowingConversion other = (NarrowingConversion) obj;
-        if (arg == null) {
-            if (other.arg != null) {
-                return false;
-            }
-        } else if (!arg.equals(other.arg)) {
-            return false;
-        }
-        return true;
-    }
-
+	@Override
+	public void accept(PrimitiveVisitor v) throws Exception {
+		v.visitNarrowingConversion(this);
+	}
 }

--- a/src/main/java/jbse/val/WideningConversion.java
+++ b/src/main/java/jbse/val/WideningConversion.java
@@ -12,98 +12,33 @@ import jbse.val.exc.ValueDoesNotSupportNativeException;
  * @author Pietro Braione
  *
  */
-public final class WideningConversion extends Primitive {
-    private final Primitive arg;
-    private final String toString;
-    private final int hashCode;
+public final class WideningConversion extends Conversion {
 
-    private WideningConversion(char type, Calculator calc, Primitive arg) 
-    throws InvalidOperandException, InvalidTypeException {
-        super(type, calc);
+	protected WideningConversion(char type, Calculator calc, Primitive arg) throws InvalidOperandException, InvalidTypeException {
+		super(type, calc, arg);
+	}
 
-        //checks on parameters
-        if (arg == null) {
-            throw new InvalidOperandException("null operand in widening construction");
-        }
-        if (!Type.widens(type, arg.getType())) {
-            throw new InvalidTypeException("cannot widen type " + arg.getType() + " to type " + type);
-        }
-        this.arg = arg;
+	public static WideningConversion make(char type, Calculator calc, Primitive arg)
+	throws InvalidOperandException, InvalidTypeException {
+		return new WideningConversion(type, calc, arg);
+	}
 
-        //calculates hashCode
-        final int prime = 281;
-        int result = 1;
-        result = prime * result + arg.hashCode();
-        result = prime * result + type;
-        this.hashCode = result;
+	@Override
+	protected String conversionAsString() {
+		return "widen";
+	}
 
-        //calculates toString
-        this.toString = "WIDEN-"+ this.getType() + "(" + arg.toString() + ")";
-    }
+	@Override
+	protected int getPrime() {
+		return 281;
+	}
 
-    public static WideningConversion make(char type, Calculator calc, Primitive arg) 
-    throws InvalidOperandException, InvalidTypeException {
-        return new WideningConversion(type, calc, arg);
-    }
+	public Primitive getArg() {
+		return this.arg;
+	}
 
-    public Primitive getArg() {
-        return this.arg;
-    }
-
-    @Override
-    public void accept(PrimitiveVisitor v) throws Exception {
-        v.visitWideningConversion(this);
-    }
-
-    @Override
-    public boolean surelyTrue() {
-        return false;
-    }
-
-    @Override
-    public boolean surelyFalse() {
-        return false;
-    }
-
-    @Override
-    public boolean isSymbolic() {
-        return true;
-    }
-
-    @Override
-    public Object getValueForNative() throws ValueDoesNotSupportNativeException {
-        throw new ValueDoesNotSupportNativeException();
-    }
-
-    @Override
-    public String toString() {
-        return this.toString;
-    }
-
-    @Override
-    public int hashCode() {
-        return this.hashCode;
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        if (this == obj) {
-            return true;
-        }
-        if (obj == null) {
-            return false;
-        }
-        if (getClass() != obj.getClass()) {
-            return false;
-        }
-        final WideningConversion other = (WideningConversion) obj;
-        if (arg == null) {
-            if (other.arg != null) {
-                return false;
-            }
-        } else if (!arg.equals(other.arg)) {
-            return false;
-        }
-        return true;
-    }
+	@Override
+	public void accept(PrimitiveVisitor v) throws Exception {
+		v.visitWideningConversion(this);
+	}
 }


### PR DESCRIPTION
Hi,

I propose to refactor conversions, _i.e._ `NarrowingConversion` and `WideningConversion`, by introducing a common supertype `Conversion`, with all the common code.

The supertype uses templates method to allow sub-classes to specify the behavior.