### PR TITLE
Fix bug for discarded triggers.

### DIFF
--- a/src/main/java/jbse/apps/settings/SettingsReader.java
+++ b/src/main/java/jbse/apps/settings/SettingsReader.java
@@ -114,7 +114,7 @@ public class SettingsReader {
      *        will add, rather than replace, to previous data in it.
      */
     public void fillEngineParameters(EngineParameters params) {
-        fillRulesTrigger(params.getTriggerRulesRepo());
+        fillRulesTrigger(params.getTriggerRulesRepoRaw());
         fillExpansionBackdoor(params.getExpansionBackdoor());
     }
 

--- a/src/main/java/jbse/jvm/EngineParameters.java
+++ b/src/main/java/jbse/jvm/EngineParameters.java
@@ -684,6 +684,10 @@ public final class EngineParameters implements Cloneable {
         }
         return retVal;
     }
+
+    public TriggerRulesRepo getTriggerRulesRepoRaw() {
+	return this.triggerRulesRepo;
+    }
     
     /**
      * Adds a regular expression pattern of class names whose 


### PR DESCRIPTION
This patch fixes issue #32 . It creates a raw getter that returns the field without copying it.

fillRulesTrigger is then called on this field instead of the copy that was discarded afterwards.