### PR TITLE
Fix bug when refine raises exception.

### DIFF
--- a/src/main/java/jbse/algo/Algorithm.java
+++ b/src/main/java/jbse/algo/Algorithm.java
@@ -268,20 +268,20 @@ UP extends StrategyUpdate<R>> implements Action {
         for (R result : decisionResults) {
             final State stateCurrent = (tot > 1 ? state.lazyClone() : state);
 
-            //pops the operands from the operand stack
-            try {
-                stateCurrent.popOperands(this.numOperands.get());
-            } catch (ThreadStackEmptyException | InvalidNumberOfOperandsException e) {
-                //this should never happen
-                failExecution(e);
-            }
-
             InterruptException interrupt = null;
             try {
                 //possibly refines the state
                 if (shouldRefine) {
                     this.refiner.refine(stateCurrent, result);
                 }
+
+		//pops the operands from the operand stack
+		try {
+		    stateCurrent.popOperands(this.numOperands.get());
+		} catch (ThreadStackEmptyException | InvalidNumberOfOperandsException e) {
+		    //this should never happen
+		    failExecution(e);
+		}
                 
             	//initializes lazily this.updated
                 if (this.updater == null) {


### PR DESCRIPTION
When refine method raises an exception, the operands that have been popped
from the stack are not restored before failing the execution. Thus, when
backtracking, the stack lacks the operands. This fix pops the operands
after refining the statement.