### PR TITLE
Allow using Signature to set a method signature

### DIFF
--- a/src/main/java/jbse/jvm/EngineParameters.java
+++ b/src/main/java/jbse/jvm/EngineParameters.java
@@ -1026,8 +1026,22 @@ public final class EngineParameters implements Cloneable {
         if (className == null || descriptor == null || name == null) {
             throw new NullPointerException();
         }
-        this.startingState = null; 
-        this.methodSignature = new Signature(className, descriptor, name); 
+        setMethodSignature(new Signature(className, descriptor, name));
+    }
+
+    /**
+     * Sets the signature of the method which must be symbolically executed,
+     * and cancels the effect of any previous call to {@link #setStartingState(State)}.
+     *
+     * @param signature the signature of the method to execute symbolically.
+     * @throws NullPointerException if any of the above parameters is {@code null}.
+     */
+    public void setMethodSignature(Signature signature) {
+        if (signature == null) {
+            throw new NullPointerException();
+        }
+        this.startingState = null;
+        this.methodSignature = signature;
     }
 
     /**

--- a/src/main/java/jbse/jvm/RunnerParameters.java
+++ b/src/main/java/jbse/jvm/RunnerParameters.java
@@ -733,6 +733,17 @@ public final class RunnerParameters implements Cloneable {
     }
 
     /**
+     * Sets the signature of the method which must be symbolically executed,
+     * and cancels the effect of any previous call to {@link #setStartingState(State)}.
+     *
+     * @param signature the signature of the method to execute symbolically.
+     * @throws NullPointerException if any of the above parameters is {@code null}.
+     */
+    public void setMethodSignature(Signature signature) {
+        this.engineParameters.setMethodSignature(signature);
+    }
+
+    /**
      * Gets the signature of the method which must be symbolically executed.
      * 
      * @return a {@link Signature}, or {@code null} if no method signature


### PR DESCRIPTION
Given the wide usage of Signature in the codebase, it might be useful to allow setting up the symbolic method to execute relying directly on a Signature.

The use case is when you are dealing with a large number of methods to execute symbolically, and you have already constructed Signatures for other purposes. This small patch allows to reuse already-constructed objects.