### PR TITLE
Break recursion if checking if Null is simple

### DIFF
--- a/src/main/java/jbse/algo/Algo_INVOKEMETA_Uninterpreted.java
+++ b/src/main/java/jbse/algo/Algo_INVOKEMETA_Uninterpreted.java
@@ -12,10 +12,7 @@ import jbse.mem.State;
 import jbse.mem.Variable;
 import jbse.mem.exc.FrozenStateException;
 import jbse.tree.DecisionAlternative_NONE;
-import jbse.val.Primitive;
-import jbse.val.Reference;
-import jbse.val.ReferenceSymbolic;
-import jbse.val.Value;
+import jbse.val.*;
 
 /**
  * {@link Algo_INVOKEMETA} implementing the effect of 
@@ -91,6 +88,8 @@ public final class Algo_INVOKEMETA_Uninterpreted extends Algo_INVOKEMETA_Nonbran
 		} else {
 			for (Variable var : obj.fields().values()) {
 				final Value val = var.getValue();
+				if (val instanceof Null)
+					return true;
 				if (val instanceof Primitive && val.isSymbolic()) {
 					return false;
 				} else if (val instanceof Reference && !isSimple(state, (Reference) val)) {


### PR DESCRIPTION
When checking whether a null object is Simple, a lacking check would generate infinite recursion in the method, causing a stack overflow in the symbolic executor.

I am anyhow not 100% confident that this patch is correct, so waiting for your feedback on this.