### PR TITLE
Expose all stored field signatures of an Objekt

### DIFF
--- a/src/main/java/jbse/mem/Objekt.java
+++ b/src/main/java/jbse/mem/Objekt.java
@@ -86,6 +86,14 @@ public interface Objekt extends Cloneable {
     Collection<Signature> getStoredFieldSignatures();
 
     /**
+     * Returns all the {@link Signature}s this {@link Objekt} stores.
+     *
+     * @return an immutable
+     *         {@link Collection}{@code <}{@link Signature}{@code >}.
+     */
+    Collection<Signature> getAllStoredFieldSignatures();
+
+    /**
      * Checks whether an object has an offset.
      * 
      * @param ofst an {@code int}.

--- a/src/main/java/jbse/mem/ObjektImpl.java
+++ b/src/main/java/jbse/mem/ObjektImpl.java
@@ -158,6 +158,11 @@ public abstract class ObjektImpl implements Objekt {
             return Collections.unmodifiableCollection(this.fieldSignatures.subList(this.numOfStaticFields, this.fieldSignatures.size()));
         }
     }
+
+    @Override
+    public final Collection<Signature> getAllStoredFieldSignatures() {
+        return Collections.unmodifiableCollection(this.fieldSignatures);
+    }
     
     private int ofstToPos(int ofst) {
         return this.fieldSignatures.size() - 1 - ofst;

--- a/src/main/java/jbse/mem/ObjektWrapper.java
+++ b/src/main/java/jbse/mem/ObjektWrapper.java
@@ -95,6 +95,11 @@ abstract class ObjektWrapper<T extends ObjektImpl> implements Objekt {
 	}
 
 	@Override
+	public final Collection<Signature> getAllStoredFieldSignatures() {
+		return getDelegate().getAllStoredFieldSignatures();
+	}
+
+	@Override
 	public final boolean hasOffset(int slot) {
 		return getDelegate().hasOffset(slot);
 	}


### PR DESCRIPTION
This patch allows to get all stored field signatures of an object.
The use case here is when someone want, e.g., to inspect an Enum and retrieve all possible constants.